### PR TITLE
mxml_load_data: do not dereference NULL on mxml_error()

### DIFF
--- a/mxml-file.c
+++ b/mxml-file.c
@@ -1659,7 +1659,7 @@ mxml_load_data(
 	  */
 
 	  mxml_error("<%s> cannot be a second root node after <%s>", 
-	             buffer, first->value.element.name);
+	             buffer, first->value.element.name ? first->value.element.name : "null");
           goto error; 		     
 	}
 
@@ -1727,7 +1727,7 @@ mxml_load_data(
 	  */
 
 	  mxml_error("<%s> cannot be a second root node after <%s>", 
-	             buffer, first->value.element.name);
+	             buffer, first->value.element.name ? first->value.element.name : "null");
           goto error; 		     
 	}
 
@@ -1794,7 +1794,7 @@ mxml_load_data(
 	  */
 
 	  mxml_error("<%s> cannot be a second root node after <%s>", 
-	             buffer, first->value.element.name);
+	             buffer, first->value.element.name ? first->value.element.name : "null");
           goto error; 		     
 	}
 
@@ -1880,7 +1880,7 @@ mxml_load_data(
 	  */
 
 	  mxml_error("<%s> cannot be a second root node after <%s>", 
-	             buffer, first->value.element.name);
+	             buffer, first->value.element.name ? first->value.element.name : "null");
           goto error; 		     
 	}
 
@@ -1972,7 +1972,7 @@ mxml_load_data(
 	  */
 
 	  mxml_error("<%s> cannot be a second root node after <%s>", 
-	             buffer, first->value.element.name);
+	             buffer, first->value.element.name ? first->value.element.name : "null");
           goto error; 		     
 	}
 


### PR DESCRIPTION
Clean up missing guards in mxml_error() calls that have been copy-and-pasted everywhere.

Not deduping the copy-paste, as it is code-smell that shows this library would benefit from several cleanups and maybe refactoring.

Fixes: pivasoftware/microxml #2 