### PR TITLE
mxml_write_node: ensure there is a space between attributes

### DIFF
--- a/mxml-file.c
+++ b/mxml-file.c
@@ -2790,13 +2790,11 @@ mxml_write_node(mxml_node_t     *node,	/* I - Node to write */
 
 	    col = 0;
 	  }
-	  else
-	  {
-	    if ((*putc_cb)(' ', p) < 0)
-	      return (-1);
 
-	    col ++;
-	  }
+	  /* https://support.easycwmp.org/view.php?id=141 */
+	  if ((*putc_cb)(' ', p) < 0)
+	    return (-1);
+	  col ++;
 
 	  if (mxml_write_name(attr->name, p, putc_cb) < 0)
 	    return (-1);


### PR DESCRIPTION
Some buggy XML parsers used in commercial ACS's can't handle LF as blank space separating attributes, so always issue a space between attributes, even if we just added a LF.

https://support.easycwmp.org/view.php?id=141